### PR TITLE
unit tests for select-form-class

### DIFF
--- a/tests/components/genveg/test_species.py
+++ b/tests/components/genveg/test_species.py
@@ -3,6 +3,7 @@ import numpy as np
 from numpy.testing import assert_allclose, assert_almost_equal
 
 from landlab.components.genveg.species import Species
+from landlab.components.genveg.form import Bunch, Colonizing, Multiplestems, Rhizomatous, Singlecrown, Singlestem, Stoloniferous, Thicketforming
 
 
 def create_species_object(example_input_params):
@@ -230,3 +231,17 @@ def test_nsc_rate_change_per_season_and_part(example_input_params):
         ncs_rate_change["fall_nsc_rate"]["stem"],
         0.015625
     )
+
+
+def test_select_form_class(example_input_params):
+    species_object = create_species_object(example_input_params)
+    dummy_growth_form = example_input_params
+    for growth, cls in zip(
+        ['bunch', 'colonizing', 'multiple_stems', 'rhizomatous', 'single_crown', 'single_stem', 'stoloniferous', 'thicket_forming'],
+        [Bunch, Colonizing, Multiplestems, Rhizomatous, Singlecrown, Singlestem, Stoloniferous, Thicketforming]
+    ):
+        dummy_growth_form["BTS"]["plant_factors"]["growth_form"] = growth
+        assert isinstance(
+            species_object.select_form_class(dummy_growth_form["BTS"]),
+            cls
+        )


### PR DESCRIPTION
Unit test will test that when the key is 'bunch', 'colonizing', 'multiple_stems', 'rhizomatous', 'single_crown', 'single_stem', 'stoloniferous', or 'thicket_forming' the correct class corresponding class is called (Bunch, Colonizing, Multiplestems, Rhizomatous, Singlecrown, Singlestem, Stoloniferous, Thicketforming)

- [x] Add a [news fragment](https://landlab.readthedocs.io/en/master/development/contribution/index.html#news-entries) file entry if necessary?
- [x] Add / update tests if necessary?
- [x] Add new / update outdated documentation?


